### PR TITLE
[docs] Fix width overflow for documentation page on mobile screen

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -81,7 +81,7 @@
                     <th>מילת מפתח מתאימה ב- JavaScript</th>
                 </tr>
                 </thead>
-                <tbody></tbody>
+                <tbody class="js-to-chava-dict"></tbody>
             </table>
         </div>
         <div class="post-content">
@@ -101,7 +101,7 @@
                     <th>מילת מפתח מתאימה ב- JavaScript</th>
                 </tr>
                 </thead>
-                <tbody></tbody>
+                <tbody class="js-to-chava-dict"></tbody>
             </table>
         </div>
     </article>

--- a/docs/main.css
+++ b/docs/main.css
@@ -59,6 +59,10 @@ body {
     .github-corner .octo-arm {
         animation: octocat-wave 560ms ease-in-out
     }
+
+    .js-to-chava-dict {
+        word-break: break-all;
+    }
 }
 
 .nav {


### PR DESCRIPTION
Mobile version of documentation page overflows its width, causing this annoying visual glitch:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/1835307/103481012-b931e500-4de0-11eb-9204-86e106517f27.png">

The CSS I added allows the line-breaks on the JS<->Chava tables to happen after underscores, like this:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/1835307/103482060-35c7c200-4de7-11eb-980c-3aedf995b887.png">

Thus not overflowing the container's width.

כרמי יא מלךךךךךךךךךךךךךךךך 🥜🦦🦌🦏🐍