### PR TITLE
Reduce transliteration boilerplate

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -23,7 +23,7 @@ export function translateIdentifierAlphabetically(identifier) {
             result += translated
         }
     }
-    return `chavascript_${result}_${simpleHash(identifier)}`
+    return `${result}_$${simpleHash(identifier).toString(36)}`
 }
 
 export function isQuote(charCode) {


### PR DESCRIPTION
Reduce transliteration boilerplate by using base-36 for hash and remove chavascript prefix
- also add "$" before the hash to put a visible barrier between the end of the hebrew word and the hash

Before:
```js
יכולת אחד() {
   יהי א = 12;
   בקרה.תעד(א);
}
```
After:
```js
function ahd_$voa4() {
    let a_$15c = 12;
    console.log(a_$15c);
}
```

Related to a comment I made at https://github.com/ChavaScript/chavascript/issues/14#issuecomment-755493307